### PR TITLE
Allow using regexes for CORS

### DIFF
--- a/fastapi_sio/utils.py
+++ b/fastapi_sio/utils.py
@@ -1,6 +1,7 @@
 from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import re
 
 
 def find_cors_configuration(app: FastAPI, default: Any) -> Any:
@@ -14,11 +15,14 @@ def find_cors_configuration(app: FastAPI, default: Any) -> Any:
             continue
 
         origins = middleware.options.get("allow_origins")
-        
-        # Incompatibility fix between CORSMiddleware and python-socketio
-        if origins == ["*"]:
-            origins = "*"
+        if origins:
+            # Incompatibility fix between CORSMiddleware and python-socketio
+            if origins == ["*"]:
+                origins = "*"
+            return origins
 
-        return origins
+        origins_regex = middleware.options.get("allow_origin_regex")
+        if origins_regex:
+            return lambda value: re.match(origins_regex, value) is not None
 
     return default

--- a/fastapi_sio/utils.py
+++ b/fastapi_sio/utils.py
@@ -4,6 +4,14 @@ from fastapi.middleware.cors import CORSMiddleware
 import re
 
 
+def match_origin(origin: str | None, pattern: str) -> bool:
+    """
+    Matches origin against a pattern.
+    """
+    return origin is not None and re.match(pattern, origin) is not None
+    
+
+
 def find_cors_configuration(app: FastAPI, default: Any) -> Any:
     """
     Looks through FastAPI's middlewares to figure
@@ -23,6 +31,6 @@ def find_cors_configuration(app: FastAPI, default: Any) -> Any:
 
         origins_regex = middleware.options.get("allow_origin_regex")
         if origins_regex:
-            return lambda value: re.match(origins_regex, value) is not None
+            return lambda origin: match_origin(origin, origins_regex)
 
     return default


### PR DESCRIPTION
Turned out that `python-socketio` lib passes the parameters into `python-engineio`, which supports callable for `cors_allowed_origins`.

So if `allowed_origins` is present in `CORSMiddleware`, it'll be applied as an exact match. If it's not, we'll check for `allow_origins_regex` and if that value is present, a simple lambda function matching that regex will be passed to `engineio` to check for match.