### PR TITLE
refactor: switch to pydantic v2

### DIFF
--- a/fastapi_sio/actors.py
+++ b/fastapi_sio/actors.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Optional, Type, TypeVar, Union
+from typing import Any, Generic, Optional, Type, TypeVar
 from pydantic import BaseModel
 from socketio import AsyncServer
 from fastapi.encoders import jsonable_encoder
@@ -8,12 +8,12 @@ T = TypeVar("T", bound=BaseModel)
 
 class SIOActorMeta(BaseModel):
     event: str
-    title: str | None
-    summary: str | None
-    description: str | None
-    model: Type[BaseModel] | None
+    title: str | None = None
+    summary: str | None = None
+    description: str | None = None
+    model: Type[BaseModel] | None = None
     media_type: str
-    message_description: str | None
+    message_description: str | None = None
 
 
 class SIOEmitterMeta(SIOActorMeta):
@@ -37,7 +37,7 @@ class SIOJsonEmitter(Generic[T]):
         return self._meta
 
     async def emit(self, payload: T, encode_kwargs = {}, **kwargs):
-        meta_args = self._meta.dict(
+        meta_args = self._meta.model_dump(
             include={
                 "include",
                 "exclude",
@@ -56,4 +56,4 @@ class SIOJsonEmitter(Generic[T]):
 
 
 class SIOHandler(SIOActorMeta):
-    name: str | None
+    name: str | None = None

--- a/fastapi_sio/schemas/asyncapi.py
+++ b/fastapi_sio/schemas/asyncapi.py
@@ -111,11 +111,11 @@ class AsyncAPIComponents(BaseModel):
 
 class AsyncAPI(BaseModel):
     asyncapi: str = ASYNCAPI_VERSION
-    id: str | None
+    id: str | None = None
     info: AsyncAPIInfo
-    servers: Dict[str, AsyncAPIServer] | None
-    defaultContentType: str | None
+    servers: Dict[str, AsyncAPIServer] | None = None
+    defaultContentType: str | None = None
     channels: Dict[str, AsyncAPIChannel]
-    components: AsyncAPIComponents | None
+    components: AsyncAPIComponents | None = None
     tags: List[AsyncAPITag] | None = None
     externalDocs: AsyncAPIExternalDocs | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 python = "^3.10"
 fastapi = ">=0.73.0,<1.0.0"
 python-socketio = ">=4.0.0,<6.0.0"
-pydantic = ">=1.9.0,<2.0.0"
+pydantic = "^2"
 websockets = ">=10.2,<11.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Refactor dropping pydantic v1 for pydantic v2.

- Added `None` defaults to optional fields to keep them not required.
- Use `.model_dump()` instead of `.dict()` according to [Migration Guide – Pydantic](https://docs.pydantic.dev/latest/migration/#migration-guide).
- Use `pydantic.json_schema.models_json_schema` to generate the top-level schema [JSON Schema – Pydantic](https://docs.pydantic.dev/latest/concepts/json_schema/#top-level-schema-generation).