### PR TITLE
fix: use kwargs instead of options on middleware when using starlette >= 0.35.0

### DIFF
--- a/fastapi_sio/utils.py
+++ b/fastapi_sio/utils.py
@@ -1,7 +1,23 @@
 from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from packaging.version import parse
 import re
+
+
+def starlette_version() -> tuple[int, int, int]:
+    from starlette import __version__
+
+    version = parse(__version__)
+
+    return version.major, version.minor, version.micro
+
+
+def get_middleware_options(middleware):
+    if starlette_version() >= (0, 35, 0):
+        return middleware.kwargs
+    else:
+        return middleware.options
 
 
 def match_origin(origin: str | None, pattern: str) -> bool:
@@ -9,7 +25,6 @@ def match_origin(origin: str | None, pattern: str) -> bool:
     Matches origin against a pattern.
     """
     return origin is not None and re.match(pattern, origin) is not None
-    
 
 
 def find_cors_configuration(app: FastAPI, default: Any) -> Any:
@@ -22,14 +37,15 @@ def find_cors_configuration(app: FastAPI, default: Any) -> Any:
         if middleware.cls is not CORSMiddleware:
             continue
 
-        origins = middleware.options.get("allow_origins")
+        options = get_middleware_options(middleware)
+        origins = options.get("allow_origins")
         if origins:
             # Incompatibility fix between CORSMiddleware and python-socketio
             if origins == ["*"]:
                 origins = "*"
             return origins
 
-        origins_regex = middleware.options.get("allow_origin_regex")
+        origins_regex = options.get("allow_origin_regex")
         if origins_regex:
             return lambda origin: match_origin(origin, origins_regex)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ fastapi = ">=0.73.0,<1.0.0"
 python-socketio = ">=4.0.0,<6.0.0"
 pydantic = "^2"
 websockets = ">=10.2,<11.0"
+packaging = "^24.1"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^22.1.0", allow-prereleases = true}


### PR DESCRIPTION
I have noticed the `find_cors_configuration` throws an exception when running on `starlette >= 0.35.0` due to a change in middlewares.

starlette < 0.35.0 used `options` as keyword arguments, see [Middleware 0.34.0](https://github.com/encode/starlette/blob/0.34.0/starlette/middleware/__init__.py#L5).
starlette >= 0.35.0 uses `kwargs` as keyword arguments, see [Middleware 0.35.0](https://github.com/encode/starlette/blob/0.35.0/starlette/middleware/__init__.py#L23).

To fix the issue the complete `release` version (i.e. `major.minor.micro`) of starlette is checked and the keyword arguments are returned by accessing the proper attribute of the middleware. Nothing else in the `find_cors_configuration` has been changed.

### Added dependency
- `packaging` for parsing the PEP 440 version of starlette